### PR TITLE
tickSpacing bug fix

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -632,9 +632,8 @@ class AxisItem(GraphicsWidget):
             maxTickCount = size / minSpacing
             if dif / intervals[minorIndex] <= maxTickCount:
                 levels.append((intervals[minorIndex], 0))
-            return levels
-        
-        
+         
+        return levels
         
         ##### This does not work -- switching between 2/5 confuses the automatic text-level-selection
         ### Determine major/minor tick spacings which flank the optimal spacing.


### PR DESCRIPTION
Fixed a bug where `tickSpacing()` would return `None` if `style['maxTickLevel'] < 2`, resulting in the axis not being drawn.