### PR TITLE
draw path all around curve filling if enabled

### DIFF
--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -502,7 +502,11 @@ class PlotCurveItem(GraphicsObject):
             p.setPen(sp)
             p.drawPath(path)
         p.setPen(cp)
-        p.drawPath(path)
+        if self.fillPath is not None:
+            p.drawPath(self.fillPath)
+        else:
+            p.drawPath(path)
+        profiler('drawPath')
         profiler('drawPath')
         
         #print "Render hints:", int(p.renderHints())


### PR DESCRIPTION
If fill-under-curve is enabled, draw a path all around the fill with the same style as the curve itself